### PR TITLE
Update _redirects.htaccess

### DIFF
--- a/_redirects.htaccess
+++ b/_redirects.htaccess
@@ -271,6 +271,7 @@ Redirect 301 /about/ /who-we-are/
 Redirect 301 /resources/ https://content.viostream.com/resources
 Redirect 301 /livemadeeasy/ https://content.viostream.com/livemadeeasy
 Redirect 301 /tedxsydney/ https://content.viostream.com/TEDxSydney
+Redirect 301 /TEDxSydney/ https://content.viostream.com/TEDxSydney
 Redirect 301 /govdigitalcomms/ https://content.viostream.com/govdigitalcomms
 
 


### PR DESCRIPTION
I am aware that https://content.viostream.com/TEDxSydney is 404, but G2M needs this redirect before the site goes live.